### PR TITLE
Dup actor hash to avoid sending bad data.

### DIFF
--- a/lib/chef/knife/group_add_actor.rb
+++ b/lib/chef/knife/group_add_actor.rb
@@ -66,10 +66,11 @@ module OpscodeAcl
     end
 
     def maybe_add_actor(type, actors)
-      if @actor_type == type && !actors.include?(@actor_id)
-          actors << @actor_id
+      new_actors = actors.dup
+      if @actor_type == type && !new_actors.include?(@actor_id)
+          new_actors << @actor_id
       end
-      actors
+      new_actors
     end
 
     def find_actor_in_map
@@ -86,4 +87,3 @@ module OpscodeAcl
     end
   end
 end
-


### PR DESCRIPTION
If we don't dup this object, the actors hash is changed, adding
possibly erroneous data to the "users" entry in make_group_for_put.
