### PR TITLE
Fix group add/remove actor

### DIFF
--- a/lib/chef/knife/group_add_actor.rb
+++ b/lib/chef/knife/group_add_actor.rb
@@ -58,7 +58,7 @@ module OpscodeAcl
         "actors" => {
           # users are added to groups via the user's USAG so we never
           # modify the users directly
-          "users" => existing_group["actors"],
+          "users" => existing_group["users"],
           "clients" => maybe_add_actor(:client, existing_group["actors"]),
           "groups" => maybe_add_actor(:user, existing_group["groups"])
         }

--- a/lib/chef/knife/group_remove_actor.rb
+++ b/lib/chef/knife/group_remove_actor.rb
@@ -20,7 +20,7 @@ module OpscodeAcl
   class GroupRemoveActor < Chef::Knife
     category "OPSCODE HOSTED CHEF ACCESS CONTROL"
     banner "knife group remove actor GROUP ACTOR"
-    attr_reader :actor_name, :group_name, :user_map, :clients    
+    attr_reader :actor_name, :group_name, :user_map, :clients
     deps do
       require 'yaml'
     end
@@ -62,9 +62,9 @@ module OpscodeAcl
         "groupname" => existing_group["groupname"],
         "orgname" => existing_group["orgname"],
         "actors" => {
-          "clients" => existing_group["actors"],
+          "clients" => existing_group["clients"],
           "groups" => existing_group["groups"],
-          "users" => existing_group["actors"]
+          "users" => existing_group["users"]
         }
       }
     end
@@ -83,4 +83,3 @@ module OpscodeAcl
     end
   end
 end
-


### PR DESCRIPTION
If a group contains both users and clients, you can run into errors when you try to populate the clients or users hashes with all members of the actors hash.
