### PR TITLE
Add a Gemfile to ensure a successful build.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+gem "rdoc", "2.4.3"
+gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,11 @@
+GEM
+  specs:
+    rake (10.0.0)
+    rdoc (2.4.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rake
+  rdoc (= 2.4.3)


### PR DESCRIPTION
Currently, attempts to build the gem may result in the following
failure:

```
uninitialized constant RDoc::Generator
```

This can be resolved by locking the version of rdoc to an older
version.  It is likely also possible to rewrite the Rakefile to be
compatible with the latest version of rake and rdoc.
