### PR TITLE
Fix for private chef group add actor for 'user'

### DIFF
--- a/lib/chef/knife/group_add_actor.rb
+++ b/lib/chef/knife/group_add_actor.rb
@@ -58,24 +58,30 @@ module OpscodeAcl
         "actors" => {
           # users are added to groups via the user's USAG so we never
           # modify the users directly
-          "users" => existing_group["users"],
-          "clients" => maybe_add_actor(:client, existing_group["actors"]),
-          "groups" => maybe_add_actor(:user, existing_group["groups"])
+          "users" => maybe_add_actor(:user, existing_group["users"]),
+          "clients" => maybe_add_actor(:client, existing_group["clients"]),
+          "groups" => maybe_add_actor(:group, existing_group["groups"])
         }
       }
     end
 
     def maybe_add_actor(type, actors)
       new_actors = actors.dup
-      if @actor_type == type && !new_actors.include?(@actor_id)
-          new_actors << @actor_id
+      if @actor_type == :user
+        if @actor_type == type && !new_actors.include?(@actor_name)
+            new_actors << @actor_name
+        end
+      else
+        if @actor_type == type && !new_actors.include?(@actor_id)
+            new_actors << @actor_id
+        end
       end
       new_actors
     end
 
     def find_actor_in_map
-      @actor_type, @actor_id = if user_map[:users][actor_name]
-                                 [:user, user_map[:users][actor_name]]
+      @actor_type, @actor_id, @actor_name = if user_map[:users][actor_name]
+                                 [:user, user_map[:users][actor_name], actor_name]
                                else
                                  [:client, clients[actor_name]]
                                end


### PR DESCRIPTION
Private chef bombs on the ID for users and the fact it wants to check on clients/groups.  Not sure if this is the right way to do this, but it works for our private chef installation.  Current knife-acl bomps like so for 'knife group add actor admins username':

INFO: HTTP Request Returned 500 Internal Server Error: Client pivotal does not exist
ERROR: Server returned error for https://chefserver/organizations/infrastructure-56m/groups/admins, retrying 3/5 in 13s

If I just remove the clients section, I get:
INFO: HTTP Request Returned 500 Internal Server Error: Users 3029dc16617811e298d590b11c089a5b do not exist
ERROR: Server returned error for https://chefserver/organizations/infrastructure-56m/groups/admins, retrying 1/5 in 4s

It seems private chef wants the username, not the ID?  This works well against a test installation, but wanted to get an official review before using it.