### PR TITLE
add/remove clients from the clients hash

### DIFF
--- a/lib/chef/knife/group_add_actor.rb
+++ b/lib/chef/knife/group_add_actor.rb
@@ -59,7 +59,7 @@ module OpscodeAcl
           # users are added to groups via the user's USAG so we never
           # modify the users directly
           "users" => existing_group["users"],
-          "clients" => maybe_add_actor(:client, existing_group["actors"]),
+          "clients" => maybe_add_actor(:client, existing_group["clients"]),
           "groups" => maybe_add_actor(:user, existing_group["groups"])
         }
       }

--- a/lib/chef/knife/group_remove_actor.rb
+++ b/lib/chef/knife/group_remove_actor.rb
@@ -47,7 +47,7 @@ module OpscodeAcl
       when :user
         group["groups"].delete(@actor_id)
       when :client
-        group["actors"].delete(@actor_id)
+        group["clients"].delete(@actor_id)
       end
       save_group(group)
     end


### PR DESCRIPTION
The actors hash is an auto-generated aggregation of users and clients.
It should not be used to make changes to users or clients hashes.

When adding clients use the clients hash from the existing_group.
When removing clients they should be removed from the clients hash.
