### PR TITLE
make sure a user is also removed from the users hash

### DIFF
--- a/lib/chef/knife/group_remove_actor.rb
+++ b/lib/chef/knife/group_remove_actor.rb
@@ -46,6 +46,7 @@ module OpscodeAcl
       case @actor_type
       when :user
         group["groups"].delete(@actor_id)
+        group["users"].delete(actor_name)
       when :client
         group["actors"].delete(@actor_id)
       end


### PR DESCRIPTION
If the management console was used to add a user to a group then its USAG wasn't
used.  Instead, its name was added to the users hash.
