### PR TITLE
Allow adding clients to permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,13 @@ default values.
 
 #### Permissions Management Best Practice
 
-The best practice for managing permissions is to only add a group to an objects' permissions.
-Then you can simply add (or remove) users or clients to the group to give the user or client
-a particular set of permissions. This is much easier to maintain when compared to adding
-individual users or clients to each objects' permissions.
+The best practice for managing permissions is to only add clients and groups to an objects' permissions.
 
-To enforce this the `knife acl add` and `knife acl bulk add` commands can only add a group
+Adding a user to an objects' permissions is possible by first adding the group to the permissions and
+then adding the user to the group. This is much easier to maintain when compared to adding
+individual users to each objects' permissions.
+
+To enforce this the `knife acl add` and `knife acl bulk add` commands can only add a client or a group
 to an objects' permissions.
 
 If a group ever needs to be removed from the permissions of all objects the group can simply
@@ -221,12 +222,17 @@ named "web.example.com":
 
     knife acl show nodes web.example.com
 
-## knife acl add group GROUP_NAME OBJECT_TYPE OBJECT_NAME PERMS
+## knife acl add MEMBER_TYPE MEMBER_NAME OBJECT_TYPE OBJECT_NAME PERMS
 
-The best practice is to only add groups to ACLs. To enforce this best practice
-the `knife acl add` command is only able to add groups to ACLs.
+The best practice is to only add clients and groups to ACLs. To enforce this best practice
+the `knife acl add` command is only able to add a client or a group to ACLs.
 
-Add `GROUP_NAME` to the `PERMS` access control entry of the `OBJECT_NAME`.
+Valid `MEMBER_TYPE` values are
+
+- client
+- group
+
+Add `MEMBER_NAME` to the `PERMS` access control entry of `OBJECT_NAME`.
 Objects are specified by the combination of their type and name.
 
 Valid `OBJECT_TYPE` values are
@@ -256,12 +262,17 @@ the ability to delete and update the node called "web.example.com":
 
     knife acl add group superusers nodes web.example.com delete,update
 
-## knife acl bulk add group GROUP_NAME OBJECT_TYPE REGEX PERMS
+## knife acl bulk add MEMBER_TYPE MEMBER_NAME OBJECT_TYPE REGEX PERMS
 
-The best practice is to only add groups to ACLs. To enforce this best practice
-the `knife acl bulk add` command is only able to add groups to ACLs.
+The best practice is to only add clients and groups to ACLs. To enforce this best practice
+the `knife acl bulk add` command is only able to add a client or a group to ACLs.
 
-Add `GROUP_NAME` to the `PERMS` access control entry for each object in a
+Valid `MEMBER_TYPE` values are
+
+- client
+- group
+
+Add `MEMBER_NAME` to the `PERMS` access control entry for each object in a
 set of objects of `OBJECT_TYPE`.
 
 The set of objects are specified by matching the objects' names with the

--- a/lib/chef/knife/acl_add.rb
+++ b/lib/chef/knife/acl_add.rb
@@ -31,12 +31,12 @@ module OpscodeAcl
 
       if name_args.length != 5
         show_usage
-        ui.fatal "You must specify the member type [group], member name, object type, object name and perms"
+        ui.fatal "You must specify the member type [client|group], member name, object type, object name and perms"
         exit 1
       end
 
-      unless member_type == 'group'
-        ui.fatal "ERROR: To enforce best practice, knife-acl can only add a group to an ACL."
+      unless %w(client group).include?(member_type)
+        ui.fatal "ERROR: To enforce best practice, knife-acl can only add a client or a group to an ACL."
         ui.fatal "       See the knife-acl README for more information."
         exit 1
       end

--- a/lib/chef/knife/acl_bulk_add.rb
+++ b/lib/chef/knife/acl_bulk_add.rb
@@ -31,12 +31,12 @@ module OpscodeAcl
 
       if name_args.length != 5
         show_usage
-        ui.fatal "You must specify the member type [group], member name, object type, object name REGEX and perms"
+        ui.fatal "You must specify the member type [client|group], member name, object type, object name REGEX and perms"
         exit 1
       end
 
-      unless member_type == 'group'
-        ui.fatal "ERROR: To enforce best practice, knife-acl can only add a group to an ACL."
+      unless %w(client group).include?(member_type)
+        ui.fatal "ERROR: To enforce best practice, knife-acl can only add a client or a group to an ACL."
         ui.fatal "       See the knife-acl README for more information."
         exit 1
       end

--- a/lib/knife-acl/version.rb
+++ b/lib/knife-acl/version.rb
@@ -1,3 +1,3 @@
 module KnifeACL
-  VERSION = "1.0.0.beta.1"
+  VERSION = "1.0.0.beta.2"
 end


### PR DESCRIPTION
We still need to be able to add clients to an objects' permissions. For example, sometimes we need to fix permissions on a node by adding its corresponding client to the ACLs. This PR allows adding clients to permissions but continues to prevent users from being added. The best way to add users to permissions continues to be by adding a group to the permissions and then adding the user to the group.