### PR TITLE
Add missing requires for chef/knife/acl_base

### DIFF
--- a/lib/chef/knife/acl_add.rb
+++ b/lib/chef/knife/acl_add.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife acl add MEMBER_TYPE MEMBER_NAME OBJECT_TYPE OBJECT_NAME PERMS"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_base.rb
+++ b/lib/chef/knife/acl_base.rb
@@ -20,10 +20,10 @@
 module OpscodeAcl
   module AclBase
 
-    PERM_TYPES = %w(create read update delete grant)
-    MEMBER_TYPES = %w(client group user)
-    OBJECT_TYPES = %w(clients containers cookbooks data environments groups nodes roles policies policy_groups)
-    OBJECT_NAME_SPEC = /^[\-[:alnum:]_\.]+$/
+    PERM_TYPES = %w(create read update delete grant) unless defined? PERM_TYPES
+    MEMBER_TYPES = %w(client group user) unless defined? MEMBER_TYPES
+    OBJECT_TYPES = %w(clients containers cookbooks data environments groups nodes roles policies policy_groups) unless defined? OBJECT_TYPES
+    OBJECT_NAME_SPEC = /^[\-[:alnum:]_\.]+$/ unless defined? OBJECT_NAME_SPEC
 
     def validate_object_type!(type)
       if ! OBJECT_TYPES.include?(type)

--- a/lib/chef/knife/acl_bulk_add.rb
+++ b/lib/chef/knife/acl_bulk_add.rb
@@ -22,6 +22,7 @@ module OpscodeAcl
     banner "knife acl bulk add MEMBER_TYPE MEMBER_NAME OBJECT_TYPE REGEX PERMS"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_bulk_remove.rb
+++ b/lib/chef/knife/acl_bulk_remove.rb
@@ -22,6 +22,7 @@ module OpscodeAcl
     banner "knife acl bulk remove MEMBER_TYPE MEMBER_NAME OBJECT_TYPE REGEX PERMS"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_remove.rb
+++ b/lib/chef/knife/acl_remove.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife acl remove MEMBER_TYPE MEMBER_NAME OBJECT_TYPE OBJECT_NAME PERMS"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_show.rb
+++ b/lib/chef/knife/acl_show.rb
@@ -22,6 +22,7 @@ module OpscodeAcl
     banner "knife acl show OBJECT_TYPE OBJECT_NAME"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_add.rb
+++ b/lib/chef/knife/group_add.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife group add MEMBER_TYPE MEMBER_NAME GROUP_NAME"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_create.rb
+++ b/lib/chef/knife/group_create.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife group create GROUP_NAME"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_destroy.rb
+++ b/lib/chef/knife/group_destroy.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife group destroy GROUP_NAME"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_list.rb
+++ b/lib/chef/knife/group_list.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife group list"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_remove.rb
+++ b/lib/chef/knife/group_remove.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife group remove MEMBER_TYPE MEMBER_NAME GROUP_NAME"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_show.rb
+++ b/lib/chef/knife/group_show.rb
@@ -23,6 +23,7 @@ module OpscodeAcl
     banner "knife group show GROUP_NAME"
 
     deps do
+      require 'chef/knife/acl_base'
       include OpscodeAcl::AclBase
     end
 


### PR DESCRIPTION
We were previously relying on load-order for this to work; however, this
doesn't work for knife-rehash which only load requested plugin.