### PR TITLE
utilize new API uspport for client/group acl granularity

### DIFF
--- a/lib/chef/knife/acl_base.rb
+++ b/lib/chef/knife/acl_base.rb
@@ -77,7 +77,7 @@ module OpscodeAcl
     end
 
     def get_acl(object_type, object_name)
-      rest.get_rest("#{object_type}/#{object_name}/_acl")
+      rest.get_rest("#{object_type}/#{object_name}/_acl?detail=granular")
     end
 
     def get_ace(object_type, object_name, perm)
@@ -92,8 +92,10 @@ module OpscodeAcl
 
         case member_type
         when "client", "user"
-          next if ace['actors'].include?(member_name)
-          ace['actors'] << member_name
+          key = "#{member_type}s"
+          key = 'actors' unless ace.has_key? key
+          next if ace[key].include?(member_name)
+          ace[key] << member_name
         when "group"
           next if ace['groups'].include?(member_name)
           ace['groups'] << member_name
@@ -111,8 +113,10 @@ module OpscodeAcl
 
         case member_type
         when "client", "user"
-          next unless ace['actors'].include?(member_name)
-          ace['actors'].delete(member_name)
+          key = "#{member_type}s"
+          key = 'actors' unless ace.has_key? key
+          next unless ace[key].include?(member_name)
+          ace[key].delete(member_name)
         when "group"
           next unless ace['groups'].include?(member_name)
           ace['groups'].delete(member_name)

--- a/lib/chef/knife/acl_show.rb
+++ b/lib/chef/knife/acl_show.rb
@@ -38,6 +38,14 @@ module OpscodeAcl
       validate_object_type!(object_type)
       validate_object_name!(object_name)
       acl = get_acl(object_type, object_name)
+      PERM_TYPES.each do |perm|
+        # Filter out the actors field if we have
+        # users and clients.  Note that if one is present,
+        # both will be - but we're checking both for completeness.
+        if acl[perm].has_key?('users') && acl[perm].has_key?('clients')
+          acl[perm].delete 'actors'
+        end
+      end
       ui.output acl
     end
   end

--- a/lib/knife-acl/version.rb
+++ b/lib/knife-acl/version.rb
@@ -1,3 +1,3 @@
 module KnifeACL
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
If the server response to ACL GET includes 'clients' and 'users'
fields, use those instead of 'actors' for submitting updates. When
showing acls, exclude 'actors' when 'clients' and 'users' are present,
since the API guarantess it will always be empty in that case.

This is backward compatible with no effect when the chef server does not support the expanded ACL API. 
