### PR TITLE
Move helpers to their own dir to speedup loading

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -1,25 +1,40 @@
 ---
+expeditor:
+  defaults:
+    buildkite:
+      timeout_in_minutes: 30
 
 steps:
 
-- label: run-specs-ruby-2.5
+- label: run-lint-and-specs-ruby-2.5
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
         image: ruby:2.5-buster
-- label: run-specs-ruby-2.6
+
+- label: run-lint-and-specs-ruby-2.6
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
         image: ruby:2.6-buster
-- label: run-specs-ruby-2.7
+
+- label: run-lint-and-specs-ruby-2.7
   command:
     - .expeditor/run_linux_tests.sh rake
   expeditor:
     executor:
       docker:
         image: ruby:2.7-buster
+
+- label: run-specs-windows
+  command:
+    - bundle install --jobs=7 --retry=3 --without docs debug
+    - bundle exec rake
+  expeditor:
+    executor:
+      docker:
+        host_os: windows

--- a/lib/chef/knife/acl_add.rb
+++ b/lib/chef/knife/acl_add.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Steven Danna (steve@chef.io)
 # Author:: Jeremiah Snapp (jeremiah@chef.io)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife acl add MEMBER_TYPE MEMBER_NAME OBJECT_TYPE OBJECT_NAME PERMS"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_bulk_add.rb
+++ b/lib/chef/knife/acl_bulk_add.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeremiah Snapp (jeremiah@chef.io)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ module OpscodeAcl
     banner "knife acl bulk add MEMBER_TYPE MEMBER_NAME OBJECT_TYPE REGEX PERMS"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_bulk_remove.rb
+++ b/lib/chef/knife/acl_bulk_remove.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Jeremiah Snapp (jeremiah@chef.io)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ module OpscodeAcl
     banner "knife acl bulk remove MEMBER_TYPE MEMBER_NAME OBJECT_TYPE REGEX PERMS"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_remove.rb
+++ b/lib/chef/knife/acl_remove.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Steven Danna (steve@chef.io)
 # Author:: Jeremiah Snapp (jeremiah@chef.io)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife acl remove MEMBER_TYPE MEMBER_NAME OBJECT_TYPE OBJECT_NAME PERMS"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/acl_show.rb
+++ b/lib/chef/knife/acl_show.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (steve@chef.io)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ module OpscodeAcl
     banner "knife acl show OBJECT_TYPE OBJECT_NAME"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_add.rb
+++ b/lib/chef/knife/group_add.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife group add MEMBER_TYPE MEMBER_NAME GROUP_NAME"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_create.rb
+++ b/lib/chef/knife/group_create.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife group create GROUP_NAME"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_destroy.rb
+++ b/lib/chef/knife/group_destroy.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Christopher Maier (<cm@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2015-2016 Chef Software, Inc.
+# Copyright:: Copyright 2015-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife group destroy GROUP_NAME"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_list.rb
+++ b/lib/chef/knife/group_list.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife group list"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_remove.rb
+++ b/lib/chef/knife/group_remove.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife group remove MEMBER_TYPE MEMBER_NAME GROUP_NAME"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/group_show.rb
+++ b/lib/chef/knife/group_show.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,7 +23,7 @@ module OpscodeAcl
     banner "knife group show GROUP_NAME"
 
     deps do
-      require_relative "acl_base"
+      require_relative "helpers/acl_base"
       include OpscodeAcl::AclBase
     end
 

--- a/lib/chef/knife/helpers/acl_base.rb
+++ b/lib/chef/knife/helpers/acl_base.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Steven Danna (steve@chef.io)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/user_dissociate.rb
+++ b/lib/chef/knife/user_dissociate.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/user_invite_add.rb
+++ b/lib/chef/knife/user_invite_add.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/user_invite_list.rb
+++ b/lib/chef/knife/user_invite_list.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/user_invite_recind.rb
+++ b/lib/chef/knife/user_invite_recind.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/user_list.rb
+++ b/lib/chef/knife/user_list.rb
@@ -1,7 +1,7 @@
 #
 # Author:: Seth Falcon (<seth@chef.io>)
 # Author:: Jeremiah Snapp (<jeremiah@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/lib/chef/knife/user_show.rb
+++ b/lib/chef/knife/user_show.rb
@@ -1,6 +1,6 @@
 #
 # Author:: Steven Danna (<steve@chef.io>)
-# Copyright:: Copyright 2011-2016 Chef Software, Inc.
+# Copyright:: Copyright 2011-2020 Chef Software, Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Knife loads anything in the lib/chef/knife/ dir so if we want to keep
something from loading each time we can stick it in a subdir.

Signed-off-by: Tim Smith <tsmith@chef.io>